### PR TITLE
OPS-437: Cache Google Ads clients instead of creating per-request

### DIFF
--- a/pkg/connector/accounts.go
+++ b/pkg/connector/accounts.go
@@ -10,15 +10,14 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	clients "github.com/shenzhencenter/google-ads-pb/clients"
 	servicespb "github.com/shenzhencenter/google-ads-pb/services"
-	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
 
 type accountBuilder struct {
-	resourceType    *v2.ResourceType
-	developerToken  string
-	customerID      string
-	credentialsJSON string
+	resourceType   *v2.ResourceType
+	developerToken string
+	customerID     string
+	customerClient *clients.CustomerClient
 }
 
 func (a *accountBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -50,14 +49,8 @@ func (a *accountBuilder) List(ctx context.Context, parentResourceID *v2.Resource
 	}
 
 	ctx = metadata.NewOutgoingContext(ctx, headers)
-	// TODO: possible issue with credentials, need to test with different account
-	c, err := clients.NewCustomerClient(ctx, option.WithCredentialsFile(a.credentialsJSON))
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("error creating customer client: %w", err)
-	}
-	defer c.Close()
 
-	accounts, err := c.ListAccessibleCustomers(ctx, req)
+	accounts, err := a.customerClient.ListAccessibleCustomers(ctx, req)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("error listing accounts: %w", err)
 	}
@@ -83,11 +76,11 @@ func (a *accountBuilder) Grants(ctx context.Context, resource *v2.Resource, pTok
 	return nil, "", nil, nil
 }
 
-func newAccountBuilder(developerToken, customerID, credentialsJSON string) *accountBuilder {
+func newAccountBuilder(developerToken, customerID string, customerClient *clients.CustomerClient) *accountBuilder {
 	return &accountBuilder{
-		resourceType:    accountResourceType,
-		developerToken:  developerToken,
-		customerID:      customerID,
-		credentialsJSON: credentialsJSON,
+		resourceType:   accountResourceType,
+		developerToken: developerToken,
+		customerID:     customerID,
+		customerClient: customerClient,
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -41,6 +41,25 @@ func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 	return nil, nil
 }
 
+// Cleanup closes the cached gRPC clients.
+func (c *Connector) Cleanup(ctx context.Context) error {
+	var errs []error
+	if c.adsClient != nil {
+		if err := c.adsClient.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if c.customerClient != nil {
+		if err := c.customerClient.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing clients: %v", errs)
+	}
+	return nil
+}
+
 // New returns a new instance of the connector.
 func New(ctx context.Context, jsonCredentialsFile, developerToken, customerID string) (*Connector, error) {
 	adsClient, err := clients.NewGoogleAdsClient(ctx, option.WithCredentialsFile(jsonCredentialsFile))

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -2,24 +2,28 @@ package connector
 
 import (
 	"context"
+	"fmt"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	clients "github.com/shenzhencenter/google-ads-pb/clients"
+	"google.golang.org/api/option"
 )
 
 type Connector struct {
 	developerToken  string
 	loginCustomerID string
-	credentialsJSON string
+	adsClient       *clients.GoogleAdsClient
+	customerClient  *clients.CustomerClient
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (c *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		newUserBuilder(c.developerToken, c.loginCustomerID, c.credentialsJSON),
-		newAccountBuilder(c.developerToken, c.loginCustomerID, c.credentialsJSON),
-		newRoleBuilder(c.developerToken, c.loginCustomerID, c.credentialsJSON),
+		newUserBuilder(c.developerToken, c.loginCustomerID, c.adsClient),
+		newAccountBuilder(c.developerToken, c.loginCustomerID, c.customerClient),
+		newRoleBuilder(c.developerToken, c.loginCustomerID, c.adsClient),
 	}
 }
 
@@ -39,9 +43,21 @@ func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 
 // New returns a new instance of the connector.
 func New(ctx context.Context, jsonCredentialsFile, developerToken, customerID string) (*Connector, error) {
+	adsClient, err := clients.NewGoogleAdsClient(ctx, option.WithCredentialsFile(jsonCredentialsFile))
+	if err != nil {
+		return nil, fmt.Errorf("error creating google ads client: %w", err)
+	}
+
+	customerClient, err := clients.NewCustomerClient(ctx, option.WithCredentialsFile(jsonCredentialsFile))
+	if err != nil {
+		adsClient.Close()
+		return nil, fmt.Errorf("error creating customer client: %w", err)
+	}
+
 	return &Connector{
 		developerToken:  developerToken,
 		loginCustomerID: customerID,
-		credentialsJSON: jsonCredentialsFile,
+		adsClient:       adsClient,
+		customerClient:  customerClient,
 	}, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -11,6 +11,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+// Connector caches the gRPC clients for the lifetime of the sync. The SDK does
+// not expose a Close/Cleanup hook for the connector itself — clients are
+// released when the process exits. Partial-init failure in New is cleaned up
+// inline.
 type Connector struct {
 	developerToken  string
 	loginCustomerID string
@@ -39,25 +43,6 @@ func (c *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 // to be sure that they are valid.
 func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, error) {
 	return nil, nil
-}
-
-// Cleanup closes the cached gRPC clients.
-func (c *Connector) Cleanup(ctx context.Context) error {
-	var errs []error
-	if c.adsClient != nil {
-		if err := c.adsClient.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if c.customerClient != nil {
-		if err := c.customerClient.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("errors closing clients: %v", errs)
-	}
-	return nil
 }
 
 // New returns a new instance of the connector.

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -14,7 +14,6 @@ import (
 	clients "github.com/shenzhencenter/google-ads-pb/clients"
 	servicespb "github.com/shenzhencenter/google-ads-pb/services"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -29,10 +28,10 @@ var roles = map[string]string{
 }
 
 type roleBuilder struct {
-	resourceType    *v2.ResourceType
-	developerToken  string
-	customerID      string
-	credentialsJSON string
+	resourceType   *v2.ResourceType
+	developerToken string
+	customerID     string
+	adsClient      *clients.GoogleAdsClient
 }
 
 func (r *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -109,12 +108,6 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 	}
 
 	ctx = metadata.NewOutgoingContext(ctx, headers)
-	// TODO: possible issue with credentials, need to test with different account
-	c, err := clients.NewGoogleAdsClient(ctx, option.WithCredentialsFile(r.credentialsJSON))
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("error creating google ads client: %w", err)
-	}
-	defer c.Close()
 
 	req := &servicespb.SearchGoogleAdsRequest{
 		CustomerId: r.customerID,
@@ -122,7 +115,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 		PageToken:  pToken.Token,
 	}
 
-	it := c.Search(ctx, req)
+	it := r.adsClient.Search(ctx, req)
 	var rv []*v2.Grant
 	for {
 		resp, err := it.Next()
@@ -145,11 +138,11 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 	return rv, "", nil, nil
 }
 
-func newRoleBuilder(developerToken, customerID, credentialsJSON string) *roleBuilder {
+func newRoleBuilder(developerToken, customerID string, adsClient *clients.GoogleAdsClient) *roleBuilder {
 	return &roleBuilder{
-		resourceType:    roleResourceType,
-		developerToken:  developerToken,
-		customerID:      customerID,
-		credentialsJSON: credentialsJSON,
+		resourceType:   roleResourceType,
+		developerToken: developerToken,
+		customerID:     customerID,
+		adsClient:      adsClient,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -13,15 +13,14 @@ import (
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	servicespb "github.com/shenzhencenter/google-ads-pb/services"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
 
 type userBuilder struct {
-	resourceType    *v2.ResourceType
-	developerToken  string
-	customerID      string
-	credentialsJSON string
+	resourceType   *v2.ResourceType
+	developerToken string
+	customerID     string
+	adsClient      *clients.GoogleAdsClient
 }
 
 func (u *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -68,12 +67,6 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 	}
 
 	ctx = metadata.NewOutgoingContext(ctx, headers)
-	// TODO: possible issue with credentials, need to test with different account
-	c, err := clients.NewGoogleAdsClient(ctx, option.WithCredentialsFile(u.credentialsJSON))
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("error creating google ads client: %w", err)
-	}
-	defer c.Close()
 
 	req := &servicespb.SearchGoogleAdsRequest{
 		CustomerId: u.customerID,
@@ -82,7 +75,7 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 	}
 
 	var rv []*v2.Resource
-	it := c.Search(ctx, req)
+	it := u.adsClient.Search(ctx, req)
 	for {
 		resp, err := it.Next()
 		if errors.Is(err, iterator.Done) {
@@ -114,11 +107,11 @@ func (u *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 	return nil, "", nil, nil
 }
 
-func newUserBuilder(developerToken, customerID, credentialsJSON string) *userBuilder {
+func newUserBuilder(developerToken, customerID string, adsClient *clients.GoogleAdsClient) *userBuilder {
 	return &userBuilder{
-		resourceType:    userResourceType,
-		developerToken:  developerToken,
-		customerID:      customerID,
-		credentialsJSON: credentialsJSON,
+		resourceType:   userResourceType,
+		developerToken: developerToken,
+		customerID:     customerID,
+		adsClient:      adsClient,
 	}
 }


### PR DESCRIPTION
## Summary
Move Google Ads gRPC client creation from per-request (every List/Grants call) to connector initialization. Clients are now cached as fields on the Connector struct and shared across all resource builders.

## Problem
Every `List()` and `Grants()` call created a new `GoogleAdsClient` or `CustomerClient`:
```go
c, err := clients.NewGoogleAdsClient(ctx, option.WithCredentialsFile(u.credentialsJSON))
defer c.Close()
```
This meant: credentials parsed, gRPC connection established, oauth2 token acquired, then immediately torn down — on every single API call. No connection reuse across paginated results or between resource types.

## Impact
Contributes to the 406k/day oauth2.googleapis.com token refresh requests seen through the squid proxy. Each new client triggers a fresh token acquisition instead of reusing a cached token.

## Changes
- `connector.go`: Create both clients in `New()`, store as struct fields
- `users.go`: Use cached `adsClient` instead of creating per-request
- `accounts.go`: Use cached `customerClient` instead of creating per-request
- `roles.go`: Use cached `adsClient` instead of creating per-request

Net: -56 lines, +51 lines (removed 3 client create/close blocks, added 1 init block).

## Test plan
- [x] `go build ./...` passes
- [ ] Verify oauth2.googleapis.com request volume decreases after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)