### PR TITLE
fix: mark developer-token as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ var (
 		"developer-token",
 		field.WithDescription("Your google ads developer token"),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 
 	CustomerIDField = field.StringField(


### PR DESCRIPTION
The `developer-token` field is the Google Ads developer token (a credential) but was a plain `field.StringField` with no `field.WithIsSecret(true)`, so it was not marked secret. This adds `WithIsSecret(true)`. `customer-id` is an identifier and `credentials-json-file-path` is a file path; both are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
